### PR TITLE
Update intel e1000e stable module 3.5.1

### DIFF
--- a/build-intel-drivers.sh
+++ b/build-intel-drivers.sh
@@ -10,7 +10,7 @@ mkdir -p $pkgdir
 URLS=" \
     https://sourceforge.net/projects/e1000/files/ixgbe%20stable/5.5.5/ixgbe-5.5.5.tar.gz/download \
     https://sourceforge.net/projects/e1000/files/igb%20stable/5.3.5.22s/igb-5.3.5.22s.tar.gz/download \
-    https://sourceforge.net/projects/e1000/files/e1000e%20stable/3.4.2.4/e1000e-3.4.2.4.tar.gz/download \
+    https://sourceforge.net/projects/e1000/files/e1000e%20stable/3.5.1/e1000e-3.5.1.tar.gz/download \
     https://sourceforge.net/projects/e1000/files/i40e%20stable/2.9.21/i40e-2.9.21.tar.gz/download \
     https://sourceforge.net/projects/e1000/files/ixgbevf%20stable/4.5.3/ixgbevf-4.5.3.tar.gz/download \
     https://sourceforge.net/projects/e1000/files/i40evf%20stable/3.6.15/i40evf-3.6.15.tar.gz/download \


### PR DESCRIPTION
I think currently exist issue with e1000e version 3.4.2.4. Propose update this driver. I have built manually 3.5.1 and now it will be testing.
Detail: NIC 82574L . Sometimes interface in bonding might goes down, and not recovered.